### PR TITLE
fix name for OpenShift service

### DIFF
--- a/istio/Installation.md
+++ b/istio/Installation.md
@@ -47,7 +47,7 @@ admissionConfig:
 ```
 cp -p master-config.yaml master-config.yaml.prepatch
 oc ex config patch master-config.yaml.prepatch -p "$(cat master-config.patch)" > master-config.yaml
-systemctl restart atomic-openshift-master*
+systemctl restart atomic-openshift-*
 ```
 
 ### Updating the Nodes


### PR DESCRIPTION
With OCP 3.10 the service is now called atomic-openshift-node. This change will instruct to restart the correct service.