### PR TITLE
MAISTRA-83 Ensure Istio components can run without the anyuid SCC

### DIFF
--- a/roles/openshift_istio/files/istio-auth.yaml
+++ b/roles/openshift_istio/files/istio-auth.yaml
@@ -1677,6 +1677,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    targetPort: webhook
   selector:
     istio: sidecar-injector
 
@@ -2855,6 +2856,10 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/tmp/health
+            - --port=8443
+          ports:
+          - name: webhook
+            containerPort: 8443
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config

--- a/roles/openshift_istio/files/istio-auth.yaml
+++ b/roles/openshift_istio/files/istio-auth.yaml
@@ -1726,8 +1726,8 @@ spec:
           - /usr/local/bin/galley
           - --meshConfigFile=/etc/mesh-config/mesh
           - --livenessProbeInterval=1s
-          - --livenessProbePath=/healthliveness
-          - --readinessProbePath=/healthready
+          - --livenessProbePath=/tmp/healthliveness
+          - --readinessProbePath=/tmp/healthready
           - --readinessProbeInterval=1s
           - --insecure=false
           - --validation-webhook-config-file
@@ -1748,7 +1748,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthliveness
+                - --probe-path=/tmp/healthliveness
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -1757,7 +1757,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthready
+                - --probe-path=/tmp/healthready
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -2854,7 +2854,7 @@ spec:
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
-            - --healthCheckFile=/health
+            - --healthCheckFile=/tmp/health
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -2870,7 +2870,7 @@ spec:
               command:
                 - /usr/local/bin/sidecar-injector
                 - probe
-                - --probe-path=/health
+                - --probe-path=/tmp/health
                 - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
@@ -2879,7 +2879,7 @@ spec:
               command:
                 - /usr/local/bin/sidecar-injector
                 - probe
-                - --probe-path=/health
+                - --probe-path=/tmp/health
                 - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4

--- a/roles/openshift_istio/files/istio-auth.yaml
+++ b/roles/openshift_istio/files/istio-auth.yaml
@@ -1429,6 +1429,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    targetPort: webhook
     name: https-validation
   - port: 9093
     name: http-monitoring
@@ -1720,7 +1721,8 @@ spec:
           image: "docker.io/istio/galley:1.1"
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 443
+          - name: webhook
+            containerPort: 8443
           - containerPort: 9093
           - containerPort: 9901
           command:
@@ -1734,6 +1736,7 @@ spec:
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort=9093
+          - --port=8443
           volumeMounts:
           - name: certs
             mountPath: /etc/certs

--- a/roles/openshift_istio/files/istio.yaml
+++ b/roles/openshift_istio/files/istio.yaml
@@ -1687,8 +1687,8 @@ spec:
           - /usr/local/bin/galley
           - --meshConfigFile=/etc/mesh-config/mesh
           - --livenessProbeInterval=1s
-          - --livenessProbePath=/healthliveness
-          - --readinessProbePath=/healthready
+          - --livenessProbePath=/tmp/healthliveness
+          - --readinessProbePath=/tmp/healthready
           - --readinessProbeInterval=1s
           - --insecure=true
           - --validation-webhook-config-file
@@ -1709,7 +1709,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthliveness
+                - --probe-path=/tmp/healthliveness
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -1718,7 +1718,7 @@ spec:
               command:
                 - /usr/local/bin/galley
                 - probe
-                - --probe-path=/healthready
+                - --probe-path=/tmp/healthready
                 - --interval=10s
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -2814,7 +2814,7 @@ spec:
             - --injectConfig=/etc/istio/inject/config
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
-            - --healthCheckFile=/health
+            - --healthCheckFile=/tmp/health
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -2830,7 +2830,7 @@ spec:
               command:
                 - /usr/local/bin/sidecar-injector
                 - probe
-                - --probe-path=/health
+                - --probe-path=/tmp/health
                 - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
@@ -2839,7 +2839,7 @@ spec:
               command:
                 - /usr/local/bin/sidecar-injector
                 - probe
-                - --probe-path=/health
+                - --probe-path=/tmp/health
                 - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4

--- a/roles/openshift_istio/files/istio.yaml
+++ b/roles/openshift_istio/files/istio.yaml
@@ -1390,6 +1390,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    targetPort: webhook
     name: https-validation
   - port: 9093
     name: http-monitoring
@@ -1681,7 +1682,8 @@ spec:
           image: "docker.io/istio/galley:1.1"
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 443
+          - name: webhook
+            containerPort: 8443
           - containerPort: 9093
           - containerPort: 9901
           command:
@@ -1695,6 +1697,7 @@ spec:
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort=9093
+          - --port=8443
           volumeMounts:
           - name: certs
             mountPath: /etc/certs

--- a/roles/openshift_istio/files/istio.yaml
+++ b/roles/openshift_istio/files/istio.yaml
@@ -1638,6 +1638,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    targetPort: webhook
   selector:
     istio: sidecar-injector
 
@@ -2815,6 +2816,10 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/tmp/health
+            - --port=8443
+          ports:
+          - name: webhook
+            containerPort: 8443
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config


### PR DESCRIPTION
There were only two things preventing them from running properly:
- they tried to write the health check files to the root folder, which isn't writable by random users (this commit moves the files to /tmp, which is writable)
- galley and sidecar-injector tried to bind to port 443, so I reconfigured them to use 8443 instead