### PR TITLE
Adds missing 1.1 attributes to chart

### DIFF
--- a/roles/openshift_istio/files/istio.yaml
+++ b/roles/openshift_istio/files/istio.yaml
@@ -3158,6 +3158,8 @@ spec:
       valueType: STRING
     request.headers:
       valueType: STRING_MAP
+    request.query_params:
+      valueType: STRING_MAP
     request.id:
       valueType: STRING
     request.host:
@@ -3165,6 +3167,8 @@ spec:
     request.method:
       valueType: STRING
     request.path:
+      valueType: STRING
+    request.url_path:
       valueType: STRING
     request.reason:
       valueType: STRING


### PR DESCRIPTION
Some additional attributes that have been added to Istio are not recognised by Mixer.
This results in errors when instances which use those attributes reference them.

This patches in-part upstream https://github.com/istio/istio/pull/11313