### PR TITLE
Reflect changes in KIALI-2340 for kiali self-monitoring

### DIFF
--- a/roles/openshift_istio/files/kiali-dashboards.yaml
+++ b/roles/openshift_istio/files/kiali-dashboards.yaml
@@ -449,7 +449,7 @@ spec:
 apiVersion: "monitoring.kiali.io/v1alpha1"
 kind: MonitoringDashboard
 metadata:
-  name: generic-go
+  name: go
 spec:
   title: Go Metrics
   runtime: Go

--- a/roles/openshift_istio/files/kiali.yaml
+++ b/roles/openshift_istio/files/kiali.yaml
@@ -284,6 +284,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        kiali.io/runtimes: go,kiali
     spec:
       serviceAccountName: kiali-service-account
       containers:


### PR DESCRIPTION
This will activate kiali "self-monitoring" by exposing metrics to prometheus and display related dashboards.

Related PR: https://github.com/kiali/kiali/pull/900

Note I haven't been able to test yet, so opening as draft. We should verify that the prometheus server scrapes kiali pod as expected.