### PR TITLE
ocp4: Add machine config for ElasticSearch

### DIFF
--- a/istio/ocp4-machine-config-elasticsearch.yaml
+++ b/istio/ocp4-machine-config-elasticsearch.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: istio-elasticsearch-sysctl
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: >-
+              data:text/plain;charset=utf-8,vm.max_map_count%20%3D%20262144
+            verification: {}
+          filesystem: root
+          mode: 444
+          path: /etc/sysctl.d/99-elasticsearch.conf


### PR DESCRIPTION
As Elasticsearch requires sysctl settings to be properly set for
startup, we need to use the OCP 4 concept of a [machine config][mc] to
set those values.  This is a working, minimal configuration that will
correctly create the sysctl dropin file that quadruples the maximum
number of memory maps for kernel allocation.